### PR TITLE
Fix for tagging build

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: nuget pack/push for tags
       run: |
-        $Branch="${{ github.head_ref }}"
+        $Branch="${{ github.ref }}"
         $Branch=$Branch -replace "refs/tags/"
         $BuildDir=(Get-Item build).FullName
         Write-Host Building Nuget Package with:


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
